### PR TITLE
docs: point contributors at the branch that exists

### DIFF
--- a/.github/scripts/test_hosting_deploy_url.sh
+++ b/.github/scripts/test_hosting_deploy_url.sh
@@ -58,8 +58,7 @@ expect 'live deploy reports the resolved site' \
   'Project Console: https://console.firebase.google.com/project/komodo-wallet-official/overview' \
   'Hosting URL: https://walletrc.web.app'
 
-# The case the old "https://$TARGET.web.app" construction got wrong: the same
-# target deployed against a different project resolves to a different site.
+# One target resolves to a different site in each project.
 expect 'live deploy to another project reports that project'"'"'s site' \
   'https://gleec-wallet-official.web.app' \
   'Project Console: https://console.firebase.google.com/project/gleec-wallet-official/overview' \

--- a/docs/CONTRIBUTION_GUIDE.md
+++ b/docs/CONTRIBUTION_GUIDE.md
@@ -17,7 +17,7 @@
 
 ## 4. Create a new branch
 
-- Create a new local branch from the `dev` branch (`master` for hotfixes), name it according to [branch naming conventions](GITFLOW_BRANCHING.md#branch-naming-conventions)
+- Create a new local branch from the `dev` branch (`main` for hotfixes), name it according to [branch naming conventions](GITFLOW_BRANCHING.md#branch-naming-conventions)
 
 ## 5. Work on the issue
 
@@ -30,7 +30,7 @@
 
 ## 6. Before creating or updating a PR (checklist)
 
-- [ ] Sync your work branch with the latest changes from the target branch (`dev` or `master`), resolve merge conflicts if any
+- [ ] Sync your work branch with the latest changes from the target branch (`dev` or `main`), resolve merge conflicts if any
 - [ ] (Re)read original issue and comments, make sure that changes are solving the issue or adding the feature
 - [ ] Run the unit suite locally — `flutter test test_units/main.dart` **with the four GasFree dart-defines** ([TESTING.md](TESTING.md#2-unit-and-widget-tests)). This is the gating CI job; without the defines it hangs rather than fails
 - [ ] Run [integration tests](TESTING.md#3-integration--gui-tests) locally
@@ -47,7 +47,7 @@
 ## 7. Create a PR (checklist)
 
 - [ ] Sync your work branch with the latest changes from the target branch (again :), push it to the remote
-- [ ] Make sure that you're opening a PR from your work branch to the proper target branch (`dev` or `master`)
+- [ ] Make sure that you're opening a PR from your work branch to the proper target branch (`dev` or `main`)
 - [ ] Provide a clear and concise title for your PR
   - [ ] Avoid using generic titles like "Fix" or "Update"
   - [ ] Avoid using the issue number in the title
@@ -66,7 +66,7 @@
 - Once your PR is created, you should maintain it until it's merged
 - Check the PR on daily basis for comments, changes requests, questions, etc.
 - Address any comments or questions from the code review, or from QA testing
-- Make sure that your PR is up to date with the target branch (`dev` or `master`), resolve merge conflicts proactively
+- Make sure that your PR is up to date with the target branch (`dev` or `main`), resolve merge conflicts proactively
 - After merging, delete your work branch
 
 ## 9. 🎉 Celebrate

--- a/docs/GITFLOW_BRANCHING.md
+++ b/docs/GITFLOW_BRANCHING.md
@@ -1,12 +1,12 @@
 # Gitflow and branching strategy
 
-1. `dev` branch is created from `master`
+1. `dev` branch is created from `main`
 2. A release branch is created from `dev` just before release (e.g. `release-0.4.2`)
 3. Feature branches are created from `dev`
 4. When a feature is complete it is merged into the `dev` branch
-5. When the release branch is done it is merged into `master` and `dev`
-6. If an issue in `master` is detected a hotfix branch is created from `master`
-7. Once the hotfix is complete it is merged to both `dev` and `master`
+5. When the release branch is done it is merged into `main` and `dev`
+6. If an issue in `main` is detected a hotfix branch is created from `main`
+7. Once the hotfix is complete it is merged to both `dev` and `main`
 
 [More...](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)
 
@@ -27,11 +27,11 @@
   - `remove-`
 - Bug fix branch (regular bug fixes):
   - `fix-`
-- Hotfix branch (hotfixes based on `master` branch):
+- Hotfix branch (hotfixes based on `main` branch):
   - `hotfix-`
 - Release branch:
   - `release-RELEASE.VERSION.NUMBER` (e.g. `release-0.4.2`)
-- Sync branch (for resolving merging conflicts between release and dev branch after merging it to master):
+- Sync branch (for resolving merging conflicts between release and dev branch after merging it to main):
   - `sync-`
 - Test branch (testing, temp branches, etc):
   - `test-`


### PR DESCRIPTION
Two small documentation corrections found while working out what this repo needs to cut a 0.9.7 release candidate.

## `master` → `main`

`docs/CONTRIBUTION_GUIDE.md` and `docs/GITFLOW_BRANCHING.md` tell contributors to branch from, sync with, and open PRs against `master`. There is no `master` on origin — only `dev` and `main`:

```bash
git ls-remote --heads origin master   # returns nothing
```

So anyone following either document for a hotfix or a release is looking for a branch that does not exist. 11 references updated.

**Deliberately left alone**, because they are not this repository's branch:

| reference | why it stays |
|---|---|
| "the release **master**" (`WEB_HOSTING_TOPOLOGY.md`) | a person, not a branch |
| `letsar/gap/blob/master/...` in two `Credit:` URLs | external repo; would 404 |
| `coins_repo_branch: "master"` + the error message quoting it | the coins repo really does use `master` |
| "Trading bot **master** toggles" (QA docs) | a UI concept |
| `MASTER.md` in vendored skill scripts | third-party file name |

## A test fixture comment

`# The case the old "https://$TARGET.web.app" construction got wrong` describes how the code came to be — which the commit that introduced it already records. Replaced with the invariant the fixture actually pins. Last item from a comment-density review across #3514 and #3518.

## Not fixed here — needs a decision, not a typo fix

`GITFLOW_BRANCHING.md` also describes `release-X.Y.Z` branches cut from `dev`. The last three releases did not use them. 0.9.5, 0.9.6 and 0.9.7 each went:

1. `chore(release): prepare X.Y.Z` → `dev`
2. a `dev` → `main` PR titled `chore(release): vX.Y.Z release candidate`

Someone should decide whether the document or the practice is wrong, and align them. Related: the `main` → `prodrc` step in `firebase-hosting-merge.yml` cannot fire (the workflow only triggers on push to `dev`, and `prodrc` is neither in `firebase.json` nor mapped in `.firebaserc`), so merging to `main` currently deploys nothing.
