### PR TITLE
fix(update): restore the hardened web update refresh flow

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -35,6 +35,39 @@
     // ],
     "headers": [
       {
+        // Version-coupled entry files must revalidate on every use. Firebase
+        // defaults to max-age=3600, so without this the in-app "Update now"
+        // reload keeps serving the build the browser already has for up to an
+        // hour -- which is what made the button look dead. UpdateBloc's
+        // hard reload clears service workers and CacheStorage, but the HTTP
+        // cache cannot be purged from JS; these headers are what cover it.
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, max-age=0, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/flutter_bootstrap.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, max-age=0, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/flutter.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, max-age=0, must-revalidate"
+          }
+        ]
+      },
+      {
         // Coin icons are a large, rarely-changing set (hundreds of files).
         // Without this they inherit Firebase's default max-age=3600, so every
         // repeat visit more than an hour apart re-validates the whole set while

--- a/lib/blocs/update_bloc.dart
+++ b/lib/blocs/update_bloc.dart
@@ -6,31 +6,55 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:web_dex/blocs/bloc_base.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/dispatchers/popup_dispatcher.dart';
-import 'package:web_dex/platform/platform.dart';
 import 'package:web_dex/services/app_update_service/app_update_service.dart';
+import 'package:web_dex/shared/utils/utils.dart';
+import 'package:web_dex/shared/utils/window/window.dart';
 import 'package:web_dex/shared/widgets/update_popup.dart';
 
 final updateBloc = UpdateBloc();
 
 class UpdateBloc extends BlocBase {
-  late Timer _checkerTime;
+  Timer? _checkerTime;
   bool _isPopupShown = false;
 
   @override
   void dispose() {
-    _checkerTime.cancel();
+    _checkerTime?.cancel();
   }
 
   Future<void> _checkForUpdates() async {
     final currentVersion = await _getCurrentAppVersion();
     final versionInfo = await appUpdateService.getUpdateInfo();
     if (versionInfo == null) return;
-    final bool isNewVersion = _isVersionGreaterThan(
+    final bool isNewVersion = isVersionGreaterThan(
       versionInfo.version,
       currentVersion,
     );
 
     if (!isNewVersion || _isPopupShown) return;
+
+    if (kIsWeb) {
+      // A reload can only ever install what the server currently hosts.
+      // Suppress the popup while the web deploy lags the announcement,
+      // otherwise it is unsatisfiable and re-appears on every check.
+      final deployedVersion = await appUpdateService.fetchDeployedWebVersion();
+      if (deployedVersion == null ||
+          !isVersionGreaterThan(deployedVersion, currentVersion)) {
+        log(
+          'Update ${versionInfo.version} announced, but the deployed web '
+          'build is ${deployedVersion ?? 'unknown'}; suppressing update popup',
+          path: 'update_bloc => _checkForUpdates',
+        );
+        return;
+      }
+    } else if (versionInfo.downloadUri == null) {
+      log(
+        'Update ${versionInfo.version} announced without a valid '
+        'download_url; suppressing update popup',
+        path: 'update_bloc => _checkForUpdates',
+      );
+      return;
+    }
 
     PopupDispatcher(
       barrierDismissible: false,
@@ -44,7 +68,7 @@ class UpdateBloc extends BlocBase {
         },
         onCancel: () {
           _isPopupShown = false;
-          _checkerTime.cancel();
+          _checkerTime?.cancel();
         },
       ),
     ).show();
@@ -56,27 +80,61 @@ class UpdateBloc extends BlocBase {
     return packageInfo.version;
   }
 
-  bool _isVersionGreaterThan(String newVersion, String currentVersion) {
-    if (newVersion == currentVersion) return false;
+  /// Compares dotted version strings segment-wise and numerically.
+  ///
+  /// Tolerates unequal segment counts ("1.0.0" > "0.9.15") and ignores
+  /// pre-release/build suffixes ("0.9.5-rc1" compares as "0.9.5"). Returns
+  /// false whenever [newVersion] is not strictly greater — including for
+  /// malformed input, so garbage from the API can never trigger the popup.
+  static bool isVersionGreaterThan(String newVersion, String currentVersion) {
+    List<int> parse(String version) {
+      final core = version.trim().split(RegExp(r'[+-]')).first;
+      return core
+          .split('.')
+          .map((s) => int.tryParse(s.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0)
+          .toList();
+    }
 
-    final int currentV = int.parse(currentVersion.replaceAll('.', ''));
-    final int newV = int.parse(newVersion.replaceAll('.', ''));
-
-    return newV > currentV;
+    final newSegments = parse(newVersion);
+    final currentSegments = parse(currentVersion);
+    final length = newSegments.length > currentSegments.length
+        ? newSegments.length
+        : currentSegments.length;
+    for (var i = 0; i < length; i++) {
+      final newSegment = i < newSegments.length ? newSegments[i] : 0;
+      final currentSegment = i < currentSegments.length
+          ? currentSegments[i]
+          : 0;
+      if (newSegment != currentSegment) return newSegment > currentSegment;
+    }
+    return false;
   }
 
   Future<void> init() async {
     await _checkForUpdates();
+    _checkerTime?.cancel();
     _checkerTime = Timer.periodic(
       const Duration(minutes: 5),
-      (_) async => await _checkForUpdates(),
+      (_) => _checkForUpdates(),
     );
   }
 
-  Future<void> update() async {
+  Future<void> update(UpdateVersionInfo versionInfo) async {
     if (kIsWeb) {
-      reloadPage();
+      await hardReloadPage();
+      return;
     }
+
+    final Uri? downloadUri = versionInfo.downloadUri;
+    if (downloadUri == null) {
+      log(
+        'App update failed: invalid download URL "${versionInfo.downloadUrl}"',
+        path: 'update_bloc => update',
+        isError: true,
+      );
+      return;
+    }
+    await launchURLString(downloadUri.toString(), inSeparateTab: true);
   }
 }
 
@@ -93,4 +151,15 @@ class UpdateVersionInfo {
   final String changelog;
   final String downloadUrl;
   final UpdateStatus status;
+
+  /// Parsed http(s) download URL, or null when absent or invalid.
+  Uri? get downloadUri {
+    final url = downloadUrl.trim();
+    if (url.isEmpty) return null;
+    final uri = Uri.tryParse(url);
+    if (uri == null || !(uri.isScheme('https') || uri.isScheme('http'))) {
+      return null;
+    }
+    return uri;
+  }
 }

--- a/lib/services/app_update_service/app_update_service.dart
+++ b/lib/services/app_update_service/app_update_service.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:web_dex/blocs/update_bloc.dart';
 import 'package:web_dex/shared/constants.dart';
+import 'package:web_dex/shared/utils/utils.dart';
+import 'package:web_dex/shared/utils/window/window.dart';
 
 const AppUpdateService appUpdateService = AppUpdateService();
 
@@ -11,9 +13,17 @@ class AppUpdateService {
 
   Future<UpdateVersionInfo?> getUpdateInfo() async {
     try {
-      final http.Response response = await http.post(
-        Uri.parse(updateCheckerEndpoint),
-      );
+      final http.Response response = await http
+          .post(Uri.parse(updateCheckerEndpoint))
+          .timeout(const Duration(seconds: 15));
+      if (response.statusCode != 200) {
+        log(
+          'Update info request failed with status ${response.statusCode}',
+          path: 'app_update_service => getUpdateInfo',
+          isError: true,
+        );
+        return null;
+      }
       final Map<String, dynamic> json = jsonDecode(response.body);
 
       return UpdateVersionInfo(
@@ -22,7 +32,51 @@ class AppUpdateService {
         changelog: json['changelog'] ?? '',
         downloadUrl: json['download_url'] ?? '',
       );
-    } catch (e) {
+    } catch (e, s) {
+      log(
+        'Failed to fetch update info: $e',
+        path: 'app_update_service => getUpdateInfo',
+        trace: s,
+        isError: true,
+      );
+      return null;
+    }
+  }
+
+  /// Returns the "version" field of the `version.json` deployed at the same
+  /// origin, or null when it cannot be determined. Only meaningful on web,
+  /// where the app is hosted at the origin root.
+  Future<String?> fetchDeployedWebVersion() async {
+    try {
+      final uri = Uri.parse('${getOriginUrl()}/version.json').replace(
+        queryParameters: {
+          // Cache-buster: defeats the HTTP cache and falls through legacy
+          // service-worker RESOURCES maps so the actual deployed file is
+          // read even on clients pinned by an old caching service worker.
+          'cb': DateTime.now().millisecondsSinceEpoch.toString(),
+        },
+      );
+      final http.Response response = await http
+          .get(uri)
+          .timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) {
+        log(
+          'version.json fetch failed with status ${response.statusCode}',
+          path: 'app_update_service => fetchDeployedWebVersion',
+          isError: true,
+        );
+        return null;
+      }
+      final dynamic json = jsonDecode(response.body);
+      final version = (json as Map<String, dynamic>)['version'] as String?;
+      return (version == null || version.isEmpty) ? null : version;
+    } catch (e, s) {
+      log(
+        'Failed to fetch deployed version.json: $e',
+        path: 'app_update_service => fetchDeployedWebVersion',
+        trace: s,
+        isError: true,
+      );
       return null;
     }
   }

--- a/lib/shared/utils/window/window_native.dart
+++ b/lib/shared/utils/window/window_native.dart
@@ -62,3 +62,7 @@ void showMessageBeforeUnload(String message) {
   _observer ??= _BeforeUnloadObserver(message);
   WidgetsBinding.instance.addObserver(_observer!);
 }
+
+/// No-op on native platforms; app updates open the release download URL
+/// instead of reloading (see UpdateBloc.update).
+Future<void> hardReloadPage() async {}

--- a/lib/shared/utils/window/window_stub.dart
+++ b/lib/shared/utils/window/window_stub.dart
@@ -5,3 +5,7 @@ String getOriginUrl() {
 void showMessageBeforeUnload(String message) {
   throw UnsupportedError('stub showMessageBeforeUnload');
 }
+
+Future<void> hardReloadPage() async {
+  throw UnsupportedError('stub hardReloadPage');
+}

--- a/lib/shared/utils/window/window_web.dart
+++ b/lib/shared/utils/window/window_web.dart
@@ -13,3 +13,50 @@ void showMessageBeforeUnload(String message) {
       ..returnValue = message;
   }.toJS;
 }
+
+/// Best-effort removal of anything that can pin the client to a stale build,
+/// then a full page reload.
+///
+/// Unregisters service workers and clears CacheStorage so the reload cannot
+/// be served from a legacy caching `flutter_service_worker.js`. The browser
+/// HTTP cache cannot be purged from JS, so entry files additionally rely on
+/// `Cache-Control: no-cache` response headers (see firebase.json).
+///
+/// Never throws; the reload always runs.
+Future<void> hardReloadPage() async {
+  try {
+    // Drop the "Are you sure you want to leave?" prompt registered by
+    // showMessageBeforeUnload so the reload is not blocked by a browser
+    // confirmation dialog.
+    web.window.onbeforeunload = null;
+  } catch (_) {}
+
+  try {
+    await _unregisterServiceWorkersAndClearCaches().timeout(
+      const Duration(seconds: 3),
+    );
+  } catch (_) {
+    // Best-effort cleanup only (insecure context, API unavailable, or
+    // timeout) — always proceed to the reload.
+  }
+
+  web.window.location.reload();
+}
+
+Future<void> _unregisterServiceWorkersAndClearCaches() async {
+  try {
+    final registrations =
+        (await web.window.navigator.serviceWorker.getRegistrations().toDart)
+            .toDart;
+    for (final registration in registrations) {
+      await registration.unregister().toDart;
+    }
+  } catch (_) {}
+
+  try {
+    final cacheKeys = (await web.window.caches.keys().toDart).toDart;
+    for (final key in cacheKeys) {
+      await web.window.caches.delete(key.toDart).toDart;
+    }
+  } catch (_) {}
+}

--- a/lib/shared/widgets/update_popup.dart
+++ b/lib/shared/widgets/update_popup.dart
@@ -4,6 +4,7 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/blocs/update_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:web_dex/shared/utils/utils.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 
 class UpdatePopUp extends StatelessWidget {
@@ -110,7 +111,17 @@ class UpdatePopUp extends StatelessWidget {
                   backgroundColor: Theme.of(context).colorScheme.secondary,
                   onPressed: () async {
                     onAccept();
-                    await updateBloc.update();
+                    Navigator.of(context).pop();
+                    try {
+                      await updateBloc.update(versionInfo);
+                    } catch (e, s) {
+                      log(
+                        'Failed to start app update: $e',
+                        path: 'update_popup => updateNow',
+                        trace: s,
+                        isError: true,
+                      );
+                    }
                   },
                 ),
               ),

--- a/lib/views/main_layout/main_layout.dart
+++ b/lib/views/main_layout/main_layout.dart
@@ -13,8 +13,7 @@ import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/analytics/events/misc_events.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
-// TODO(migration): Re-enable once update checker endpoint is migrated
-// import 'package:web_dex/blocs/update_bloc.dart';
+import 'package:web_dex/blocs/update_bloc.dart';
 import 'package:web_dex/common/screen.dart';
 
 import 'package:web_dex/model/authorize_mode.dart';
@@ -71,8 +70,7 @@ class _MainLayoutState extends State<MainLayout> {
     final tradingStatusBloc = context.read<TradingStatusBloc>();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      // TODO(migration): Re-enable once update checker endpoint is migrated
-      // await updateBloc.init();
+      await updateBloc.init();
 
       if (mounted) {
         try {

--- a/test_units/main.dart
+++ b/test_units/main.dart
@@ -61,6 +61,7 @@ import 'tests/helpers/max_min_rational_tests.dart';
 import 'tests/helpers/total_24_change_tests.dart';
 import 'tests/helpers/total_fee_test.dart';
 import 'tests/helpers/update_sell_amount_tests.dart';
+import 'tests/helpers/update_version_compare_tests.dart';
 import 'tests/gasless/tron_gasless_policy_test.dart';
 import 'tests/password/validate_password_tests.dart';
 import 'tests/password/validate_rpc_password_tests.dart';
@@ -176,6 +177,7 @@ void main() {
     testGetTotalFee();
     testGetSellAmount();
     testUpdateSellAmount();
+    testUpdateVersionCompare();
   });
 
   testTronGaslessPolicy();

--- a/test_units/tests/helpers/update_version_compare_tests.dart
+++ b/test_units/tests/helpers/update_version_compare_tests.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_dex/blocs/update_bloc.dart';
+
+void main() => testUpdateVersionCompare();
+
+void testUpdateVersionCompare() {
+  group('UpdateBloc.isVersionGreaterThan:', () {
+    test('basic ordering', () {
+      expect(UpdateBloc.isVersionGreaterThan('0.9.5', '0.9.4'), true);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.4', '0.9.5'), false);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.5', '0.9.5'), false);
+      expect(UpdateBloc.isVersionGreaterThan('0.10.0', '0.9.5'), true);
+    });
+
+    test('unequal segment counts and digit widths', () {
+      expect(UpdateBloc.isVersionGreaterThan('1.0.0', '0.9.15'), true);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.15', '1.0.0'), false);
+      expect(UpdateBloc.isVersionGreaterThan('1.0', '1.0.0'), false);
+      expect(UpdateBloc.isVersionGreaterThan('1.0.1', '1.0'), true);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.10', '0.9.9'), true);
+    });
+
+    test('non-numeric suffixes and garbage never throw', () {
+      expect(UpdateBloc.isVersionGreaterThan('0.9.5-rc1', '0.9.4'), true);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.5-rc1', '0.9.5'), false);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.5+7', '0.9.5'), false);
+      expect(UpdateBloc.isVersionGreaterThan('', '0.9.5'), false);
+      expect(UpdateBloc.isVersionGreaterThan('abc', '0.9.5'), false);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.5', ''), true);
+    });
+  });
+
+  group('UpdateVersionInfo.downloadUri:', () {
+    UpdateVersionInfo info(String url) => UpdateVersionInfo(
+      status: UpdateStatus.available,
+      version: '1.0.0',
+      changelog: '',
+      downloadUrl: url,
+    );
+
+    test('accepts http(s) URLs', () {
+      expect(
+        info(
+          'https://github.com/GLEECBTC/gleec-wallet/releases/tag/0.9.5',
+        ).downloadUri.toString(),
+        'https://github.com/GLEECBTC/gleec-wallet/releases/tag/0.9.5',
+      );
+      expect(info(' https://example.com ').downloadUri, isNotNull);
+      expect(info('http://example.com').downloadUri, isNotNull);
+    });
+
+    test('rejects empty, non-http, and malformed URLs', () {
+      expect(info('').downloadUri, isNull);
+      expect(info('   ').downloadUri, isNull);
+      expect(info('javascript:alert(1)').downloadUri, isNull);
+      expect(info('ftp://example.com/file').downloadUri, isNull);
+      expect(info('not a url').downloadUri, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Restores the web update-refresh fix, which `dev` lost and never got back.

Found while sweeping the commit behind https://github.com/GLEECBTC/gleec-wallet/pull/3520 — both regressions came out of the same place.

## What happened

`e7e07bbc4` *"fix(update): harden web update refresh flow"* landed the fix on `add/gas-free-tron`. Three weeks later `689b75146` *"chore(updates): defer checks until endpoint migration"* reverted it deliberately, and `1db8667de` carried the same revert onto the branch that merged. Both are still reverted on `dev`: `hardReloadPage` does not exist anywhere in `lib/`, `main_layout.dart` still carries `// TODO(migration): Re-enable once update checker endpoint is migrated` over a commented-out `updateBloc.init()`, `firebase.json` has no entry-file cache headers at all, and `test_units/tests/helpers/update_version_compare_tests.dart` is gone.

## The stated blocker is gone

The endpoint the descope was waiting on is live and correct:

```
$ curl -sX POST https://defistats.gleec.com/api/v3/dex_version
{"status":"recommended","new_version":"0.9.6","changelog":"…","download_url":"https://github.com/GLEECBTC/gleec-wallet/releases/tag/0.9.6"}
```

## This changes nothing today, on purpose

`pubspec.yaml` is `0.9.7+0` and the endpoint announces `0.9.6`, so no popup can appear until someone bumps the endpoint. What this PR does is make that bump safe, because the shape that breaks the button is already live: the endpoint announces `0.9.6` while `dex.gleec.com/version.json` still reports the deployed web build as `0.9.4`. Re-enabling the checker without the guards below would put a web user in front of an "Update now" button that reloads them onto the same build they already have, forever.

## What comes back

- **`UpdateBloc` gates the popup on what is actually installable.** On web it compares against the *deployed* build from `version.json` and stays quiet while the announcement runs ahead of the deploy. On native it requires a valid `download_url` rather than opening an empty one. `_checkerTime` becomes nullable, so an update check that never started cannot throw on dispose.
- **`hardReloadPage()`** unregisters service workers and clears CacheStorage before reloading, so the reload cannot be served by a legacy caching `flutter_service_worker.js`. It drops the `beforeunload` handler first, so the reload is not blocked by a confirmation dialog, and it never throws — the reload always runs.
- **Entry-file cache headers in `firebase.json`.** The HTTP cache cannot be purged from JS, so `hardReloadPage` alone is not enough: Firebase's default `max-age=3600` keeps serving the old `index.html` / `flutter_bootstrap.js` / `flutter.js` for up to an hour after a deploy. These three `no-cache, must-revalidate` entries are the other half of the same fix.
- **`UpdatePopUp` awaits the update behind a try/catch and pops the dialog first**, instead of leaving a dead modal up when the update throws.
- **`testUpdateVersionCompare()`** — segment-wise version comparison coverage, restored and re-registered in `test_units/main.dart`.

## Conflict to expect

The `firebase.json` hunk will conflict with https://github.com/GLEECBTC/gleec-wallet/pull/3514, which restructures the same `headers` array. The resolution is to keep both: three new entry-file blocks here, its security headers and `/assets/assets/web_pages/**` block there. Nothing in either edit contradicts the other — Firebase applies the headers of every matching entry.

## Testing

`flutter test test_units/main.dart` with CI's dart-defines. `flutter analyze` clean on every touched file, apart from a pre-existing `use_super_parameters` info on `UpdatePopUp`'s constructor that is identical on `dev`. `dart format` clean, `pubspec.lock` untouched. `firebase.json` still parses once its comments are stripped.

Not verified in a browser: the reload path needs a deployed build newer than the client's, which is a deploy this PR does not make.
