### PR TITLE
chore(sdk): roll the submodule to the 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ This release adds gas-free TRC-20 sends and receives on TRON, cuts the wait on a
 - **Rolled to `3.1.0-beta` (`f3efd2c`)** ([@CharlVS], #3500) - The engine moves to the `main` release line, which carries the merged gas-free support this release depends on.
 - **EVM Swap Gas Limits Roughly Double** ([@CharlVS], #3500) - The engine reprices EVM swap gas for the Amsterdam/Bogota fork rules. A DEX fee estimate for an ETH pair goes 165,000 → 280,000 gas, and for an ERC-20/GRC-20 pair 300,000 → 540,000. The same figures back the pre-trade balance check, so a wallet holding *just* enough platform coin to cover the old estimate will now report insufficient funds. This is correct under the new fork rules - the old limits would have under-funded the transaction - but it is a visible change to fee previews rather than a regression.
 - **Priority Fee Estimates Move** ([@CharlVS], #3500) - The simple EIP-1559 estimator now reads the pending block's base fee rather than the oldest entry in its window, so priority-fee estimates shift.
+### SDK (komodo-defi-sdk-flutter)
+
+- **Rolled to the `0.7.0` Release Line** (SDK#360, SDK#367) - The submodule was pinned to a mid-review snapshot of the branch that became SDK#360, taken before that pull request's final review round merged. The pin advances to the released `0.7.0` commit on SDK `main`, which carries 24 fixes to the exact paths this release advertises: the gas-free withdrawal journal, persisted transaction history, balance watching across a degraded wallet identity, activation state, and the cache purge on wallet deletion. The trading engine artefact is unchanged at `f3efd2c`.
+- **KDF Downloads Restricted to Official Mirrors** (SDK#373) - Two third-party hosts were dropped from the trading-engine download sources, leaving only Gleec's own build host and the upstream mirror.
 
 ## 🔧 Technical Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Gleec Wallet v0.9.7 Release Notes
 
-This release adds gas-free TRC-20 sends and receives on TRON, cuts the wait on a fresh HD sign-in, makes transaction history survive a restart, and reworks wallet setup so the create-or-import decision, the terms you agree to, and the prompt to save your recovery phrase all happen where they belong. It also rolls the native trading engine to the `3.1.0-beta` line, which reprices EVM swap gas under the Amsterdam/Bogota fork rules and is visible in DEX fee estimates.
+This release adds gas-free TRC-20 sends and receives on TRON, cuts the wait on a fresh HD sign-in, makes transaction history survive a restart, and reworks wallet setup so the create-or-import decision, the terms you agree to, and the prompt to save your recovery phrase all happen where they belong. It gives every supported NFT chain its own tab that enables the chain on tap, and rolls the native trading engine to the `3.1.0-beta` line, which reprices EVM swap gas under the Amsterdam/Bogota fork rules and is visible in DEX fee estimates.
 
 ## 🚀 New Features
 
 - **TRON Gas-Free Sends & Receives** ([@CharlVS], #3500) - Send and receive TRC-20 tokens on TRON without holding TRX for gas, using the custody-address model and the GasFree relay. Includes the send and receive flows, address handling, and the supporting transaction history.
 - **Transaction History Survives a Restart** ([@CharlVS], #3500) - Transaction history is now cached on disk between sessions. A coin's details page renders the history it already knows on a cold start instead of waiting for the first network round trip, and the walk that follows becomes a refresh rather than a cold fetch. On by default; retention is deliberately unbounded.
+- **An NFT Tab for Every Supported Chain** ([@CharlVS], #3523) - The NFT page now shows a tab for every catalogue chain available in your region rather than only the chains already enabled, and tapping an un-enabled one activates it. A tab reports **Not enabled**, a spinner, or **Couldn't enable** instead of a count, so a chain nobody has queried can never read as "you own nothing here". Browsing a chain is session-scoped: it does not add the coin to your wallet or to the next sign-in's set.
 
 ## ⚡ Performance Enhancements
 
@@ -30,6 +31,8 @@ This release adds gas-free TRC-20 sends and receives on TRON, cuts the wait on a
 - **Activation Could Hang Forever on a Silent Progress Stream** ([@CharlVS], #3500) - A stream that never emitted and never closed suspended before the caller received its future, so the deadline fired while the caller kept waiting.
 - **Activation Timeout Fired Mid-Login and Issued Duplicate Requests** ([@CharlVS], #3500) - A flat 60-second deadline fired during every fresh HD login, and the retry started a second concurrent activation. Timeouts are now protocol-aware.
 - **Login Form No Longer Reads the Clipboard** ([@CharlVS], #3500) - The password field auto-filled from the system clipboard. Removed.
+- **Enabling an NFT Chain Could Silence a Coin You Already Hold** ([@CharlVS], #3523) - Enabling a chain from the NFT page suppressed that asset's activation broadcasts for the rest of the session. That is right for a chain the NFT page brings up on its own and wrong for a held coin whose activation had failed: its wallet row then stayed silent until the next sign-in.
+- **The NFT Retry Button Spun Forever** ([@CharlVS], #3523) - Every NFT failure screen shipped a permanently-spinning Retry button, from an inverted spinner condition no caller could get right.
 - **NFT Chain Activation Reported Incorrectly** ([@CharlVS], #3509) - The NFT screen could tell you to enable a chain that was already enabled. Chain activation state now comes from a single source of truth.
 
 ## 💻 Platform-Specific Changes
@@ -51,10 +54,12 @@ This release adds gas-free TRC-20 sends and receives on TRON, cuts the wait on a
 - **Wallet-Load Measurement Harness** ([@CharlVS], #3500) - A test harness running a real SDK with only the RPC backend faked, so authentication, activation, public keys, balances and storage are exercised as production code. A replay tier gates every pull request and a real-engine tier runs nightly. 18 test files that existed but had never been registered now run, and the real failures they surfaced are fixed.
 - **Alpha Testing Notice Removed** ([@CharlVS], #3509) - The alpha-testing disclaimer shown on launch has been removed; the risk disclosure lives in the EULA and Terms. This also stops the notice from silently re-enabling analytics for users who had turned them off.
 - **KDF Performance Stack Descoped** ([@CharlVS], #3500) - Three engine-side performance changes - a concurrent HD gap scan, concurrent EVM RPCs with connection pooling, and EVM/TRON rate-limit backoff - are not in this build. What each would add, and the regressions accepted without them, are recorded in [`docs/KDF_PERF_STACK_DESCOPE.md`](docs/KDF_PERF_STACK_DESCOPE.md). The client-side half of that work does ship, and is what the performance section above measures.
+- **Web Deploys Use the Site the CLI Actually Published To** ([@CharlVS], #3518) - The deploy workflow treated its Firebase deploy target as though it were a site ID. The two names only coincided in the one project previews run against, and #3500 made them diverge, so a preview link could point at a site the build never reached. The workflow now reads the resolved site out of the Firebase CLI's own output, and the target is renamed from `walletrc` to `web`.
 
 ## 📚 Documentation
 
 - **Measurement Captures Lifted Out of the Repository** ([@CharlVS], #3516) - Retire the spent KDF measurement documents and their raw capture data, and correct the ones that no longer describe the shipped build - roughly 15,000 lines removed. The wallet-load performance report was deleted outright: its headline figure was measured against the descoped engine stack and is false for what ships here.
+- **Contributor Docs Point at a Branch That Exists** ([@CharlVS], #3519) - The contribution and branching guides told contributors to branch from, sync with, and open pull requests against `master`, which this repository does not have. 11 references corrected to `main`.
 
 **Full Changelog**: [0.9.6...0.9.7](https://github.com/GLEECBTC/gleec-wallet/compare/0.9.6...0.9.7)
 

--- a/docs/SDK_SUBMODULE_MANAGEMENT.md
+++ b/docs/SDK_SUBMODULE_MANAGEMENT.md
@@ -13,7 +13,7 @@ The Gleec Wallet project uses the komodo-defi-sdk-flutter repository as a git su
 
 ## Initial Setup
 
-The `sdk/` submodule is configured to track the `dev` branch but stays pinned to a specific commit in this repository. Cloning should initialize it to the recorded (pinned) commit, not the latest.
+The `sdk/` submodule is configured to track the `main` branch (see `.gitmodules`) but stays pinned to a specific commit in this repository. Cloning should initialize it to the recorded (pinned) commit, not the latest.
 
 Recommended (initializes submodules at the pinned commits while cloning):
 
@@ -27,21 +27,21 @@ If you already cloned without submodules:
 git submodule update --init --recursive
 ```
 
-Either approach ensures the SDK in `sdk/` is checked out at the pinned commit recorded by the wallet repository (the submodule tracks `dev`, but does not auto-advance).
+Either approach ensures the SDK in `sdk/` is checked out at the pinned commit recorded by the wallet repository (the submodule tracks `main`, but does not auto-advance).
 
 ## Working with the SDK Submodule
 
 ### Updating to Latest SDK Changes (explicit)
 
-The SDK submodule only updates when explicitly requested. To advance the pinned commit to the latest on the tracked `dev` branch:
+The SDK submodule only updates when explicitly requested. To advance the pinned commit to the latest on the tracked `main` branch:
 
 ```bash
 git submodule update --remote --checkout sdk
 git add sdk
-git commit -m "chore(sdk): update submodule to latest dev"
+git commit -m "chore(sdk): update submodule to latest main"
 ```
 
-This updates the submodule to the latest remote `dev` commit and records that pinned commit in the wallet repo. It does not merge or rebase inside the submodule.
+This updates the submodule to the latest remote `main` commit and records that pinned commit in the wallet repo. It does not merge or rebase inside the submodule.
 
 ### Making SDK Changes (Hotfix Workflow)
 
@@ -134,7 +134,7 @@ With these settings, `git switch`/`git checkout` and `git pull` will recurse int
 - **Always commit submodule changes** in the wallet repository when updating the SDK
 - **Test thoroughly** before pushing submodule updates
 - **Use descriptive commit messages** when updating the submodule (e.g., "Update SDK to v2.4.0 with new trading features")
-- **Keep the submodule on `dev` branch** for production builds
+- **Pin the submodule to an SDK `main` commit** for release builds, so the pin stays reachable from a branch
 - **Use hotfix branches** for urgent SDK fixes
 - **Document breaking changes** when updating the SDK
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -704,77 +704,77 @@ packages:
       path: "sdk/packages/komodo_cex_market_data"
       relative: true
     source: path
-    version: "0.1.0+1"
+    version: "0.1.0+2"
   komodo_coin_updates:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_coin_updates"
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.1.0"
   komodo_coins:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_coins"
       relative: true
     source: path
-    version: "0.3.2+1"
+    version: "0.4.0"
   komodo_defi_framework:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_framework"
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.5.0"
   komodo_defi_local_auth:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_local_auth"
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.5.0"
   komodo_defi_rpc_methods:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_defi_rpc_methods"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.6.0"
   komodo_defi_sdk:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_defi_sdk"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.7.0"
   komodo_defi_types:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_defi_types"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.5.0"
   komodo_legacy_wallet_migration:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_legacy_wallet_migration"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   komodo_ui:
     dependency: "direct main"
     description:
       path: "sdk/packages/komodo_ui"
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.3.3"
   komodo_wallet_build_transformer:
     dependency: "direct overridden"
     description:
       path: "sdk/packages/komodo_wallet_build_transformer"
       relative: true
     source: path
-    version: "0.4.2"
+    version: "0.5.0"
   leak_tracker:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Rolls the `sdk` submodule from `21474ce3` to `7dce2687` — the tip of SDK `main`, which is the `0.7.0` release merge (SDK#367).

This should land on `dev` before the `0.9.7` release candidate.

## Why the current pin is wrong

`dev` pins `21474ce3`, the head of `chore/roll-kdf-main-descope` at the moment the wallet last snapshotted it. Two things are wrong with that commit:

**It is on no branch.** The branch was squashed into SDK#360 and deleted:

```bash
git -C sdk branch -r --contains 21474ce3   # returns nothing
```

It is still fetchable today, but nothing keeps it that way.

**It was taken mid-review.** 24 `fix(...)` commits landed on that branch *after* the snapshot and *before* SDK#360 merged:

```bash
git -C sdk log --oneline 21474ce3..origin/perf/hd-gap-scan-and-ws-transport --grep='^fix(' | wc -l
# 24
```

They are not cosmetic. They repair the paths `0.9.7` advertises in its release notes:

<details>
<summary>All 24, oldest first</summary>

- `fix(ci): pin the resolved commit and mirror when rolling the KDF artefact`
- `fix(history): reject Blockscout error envelopes instead of reading them as empty`
- `fix(sdk): scope the transaction store to its own SDK container`
- `fix(assets): let only the owning fetch clear the activated-assets slot`
- `fix(auth): expire the generated-wallet marker with its first session`
- `fix(activation): sweep authoritative empty reads and keep terminal errors`
- `fix(history): commit the order index only after Hive writes land`
- `fix(history): normalise overlong ids in order-index lookups`
- `fix(framework): keep the local RPC dial-out on plain HTTP`
- `fix(balances): compare the stale guard against the pre-fetch balance`
- `fix(assets): expose lookup indexes as unmodifiable views`
- `fix(withdrawals): propagate discard failures for pending gas-free transfers`
- `fix(sdk): let operations continue across a degraded wallet identity`
- `fix(history): drop unreadable rows from the order index and share one store per box`
- `fix(sdk): acquire the shared transaction store in bootstrap`
- `fix(history): collapse re-keyed duplicates when rebuilding the index`
- `fix(sdk): single-flight the threshold backstop probes`
- `fix(history): serialize the final box close with the next acquire`
- `fix(auth): await wallet-cache purges before deleteWallet returns`
- `fix(history): let opaque strategy cursors fall through to the strategy`
- `fix(balances): start the balance watcher across a degraded identity`
- `fix(activation): keep the cancellation reason in the activation state`
- `fix(history): stop losing rows and box handles on a failed storage op`
- `fix(withdrawals): make the gas-free journal discard atomic`

</details>

Mapped against what the release notes promise:

| `0.9.7` claims | fix missing from the pin |
|---|---|
| gas-free TRC-20 sends | journal discard is not atomic; discard failures are swallowed |
| transaction history survives a restart | a failed storage op loses rows and box handles; the order index commits before Hive writes land |
| GLEEC / GRC-20 history served from Blockscout | error envelopes are read as an empty list |
| deleting a wallet purges its caches | `deleteWallet` returns before the purges finish |
| a transport blip no longer signs you out | the balance watcher refuses to start across a degraded identity |
| activation no longer hangs | the cancellation reason is dropped from activation state |

`GaslessJournalDiscardOutcome`, added by the journal fix, is exported from SDK `main` and absent at the pin — a one-symbol check that the snapshot really does predate them.

## What else comes with the roll

- **Workspace versions stop being placeholders.** The snapshot carried `1.0.0` for `komodo_defi_sdk`, `komodo_defi_types` and `komodo_defi_rpc_methods`. `0.7.0` gives them real semver, which is why `pubspec.lock` moves those three *down* — to `0.7.0`, `0.5.0` and `0.6.0`. Nothing is downgraded; the placeholders were never a release.
- **KDF downloads restricted to official mirrors** (SDK#373): `kdf-dev-builds.nitride.app` and `nitride-kdf-builds.web.app` are gone from `source_urls`, leaving `devbuilds.gleec.com` and `nebula.decker.im`.
- **The trading engine artefact does not move.** `api_commit_hash` is `f3efd2c` on both sides, so the KDF binary this release ships is the one `0.9.7` was tested against.

```bash
# identical before and after
jq -r .api.api_commit_hash sdk/packages/komodo_defi_framework/app_build/build_config.json
```

## Second commit: the release notes

#3512 wrote the `0.9.7` notes. #3518, #3519 and #3523 merged into `dev` afterwards and were never added. #3523 is the omission that matters — a user-visible feature (an NFT tab for every supported chain, enabling the chain on tap) and two bugs it fixes, including a held coin's wallet row going silent for the rest of the session after enabling a chain from the NFT page.

It is a separate commit; drop it if the team would rather the notes stay as `0.9.7` prep left them.

## A documentation correction

`.gitmodules` has tracked SDK `main` since #3474, but `docs/SDK_SUBMODULE_MANAGEMENT.md` still says the submodule tracks `dev`. Anyone following its `git submodule update --remote` instructions gets `main` and a document that told them otherwise. Corrected, along with the "keep the submodule on `dev` branch" guidance, which is what produced an unreachable pin in the first place.

## Verification

```bash
fvm flutter pub get                        # Changed 1 dependency; no third-party churn in pubspec.lock
fvm flutter analyze --no-pub               # 0 errors (2137 info, 58 warning — unchanged classes, incl. sdk/)
fvm flutter test test_units/main.dart \
  --dart-define=TRON_GASLESS_ENABLED=true \
  --dart-define=TRON_GASLESS_RECEIVE_ENABLED=true \
  --dart-define=TRON_GASLESS_BASE_URL=... \
  --dart-define=TRON_GASLESS_SERVICE_PROVIDER=...
# 00:22 +698 ~3: All tests passed!
```

`pubspec.lock` changes only the eleven `sdk/packages/*` path entries — no transitive package moved, which is the tell that this was resolved on the CI-pinned Flutter 3.41.4 and not a newer local toolchain.

## Not done here

The `komodo_defi_sdk-v0.6.0` and `-v0.7.0` package tags still do not exist upstream:

```bash
git -C sdk ls-remote --tags origin | grep -E 'komodo_defi_sdk-v0\.[5-9]'   # returns nothing
```

`0.9.6`'s release candidate asked for the `0.6.0` tag and it was never created. The wallet resolves the SDK through path dependencies on the submodule, so nothing breaks — but the version references in the release notes do not resolve. Tracked in #3510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
