### PR TITLE
fix(update): re-enable the update check and make the reload land

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -88,6 +88,33 @@
         ]
       },
       {
+        // The boot files that carry the app's version. Every one of these is
+        // served at a stable, un-hashed name, so a client that has any of them
+        // in its HTTP cache keeps running the build it already has -- and
+        // Firebase's default is max-age=3600, so that lasts an hour.
+        //
+        // This is what actually breaks the in-app "Update now" button. It is
+        // not a service worker: both deployed sites serve Flutter's modern
+        // self-unregistering worker (no RESOURCES map, caches nothing), so
+        // there is no SW cache left to defeat. The HTTP cache is the whole
+        // problem, and JS cannot purge it -- only these headers can.
+        //
+        // main.dart.js is the compiled app itself and is the one most easily
+        // missed: revalidating index.html alone just re-serves a fresh shell
+        // that boots an hour-old application.
+        //
+        // version.json is here because UpdateBloc reads it to decide whether a
+        // reload could install anything (see update_bloc.dart). A stale copy
+        // makes that decision on stale data.
+        "source": "/@(index.html|flutter_bootstrap.js|flutter.js|main.dart.js|flutter_service_worker.js|version.json)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, max-age=0, must-revalidate"
+          }
+        ]
+      },
+      {
         // Coin icons are a large, rarely-changing set (hundreds of files).
         // Without this they inherit Firebase's default max-age=3600, so every
         // repeat visit more than an hour apart re-validates the whole set while

--- a/lib/blocs/update_bloc.dart
+++ b/lib/blocs/update_bloc.dart
@@ -6,31 +6,70 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:web_dex/blocs/bloc_base.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/dispatchers/popup_dispatcher.dart';
-import 'package:web_dex/platform/platform.dart';
 import 'package:web_dex/services/app_update_service/app_update_service.dart';
+import 'package:web_dex/shared/utils/utils.dart';
+import 'package:web_dex/shared/utils/window/window.dart';
 import 'package:web_dex/shared/widgets/update_popup.dart';
 
 final updateBloc = UpdateBloc();
 
 class UpdateBloc extends BlocBase {
-  late Timer _checkerTime;
+  /// How long an established "this site cannot serve that release yet" verdict
+  /// is trusted before it is re-checked.
+  static const Duration _gateRecheckInterval = Duration(minutes: 30);
+
+  Timer? _checkerTime;
   bool _isPopupShown = false;
+
+  String? _gateAnnouncedVersion;
+  DateTime? _gateCheckedAt;
 
   @override
   void dispose() {
-    _checkerTime.cancel();
+    _checkerTime?.cancel();
+  }
+
+  Future<void> init() async {
+    await _checkForUpdates();
+    // init() is reachable more than once across a session; without this each
+    // call would leave another live timer behind.
+    _checkerTime?.cancel();
+    _checkerTime = Timer.periodic(
+      const Duration(minutes: 5),
+      (_) => _checkForUpdates(),
+    );
   }
 
   Future<void> _checkForUpdates() async {
     final currentVersion = await _getCurrentAppVersion();
     final versionInfo = await appUpdateService.getUpdateInfo();
     if (versionInfo == null) return;
-    final bool isNewVersion = _isVersionGreaterThan(
+
+    final bool isNewVersion = isVersionGreaterThan(
       versionInfo.version,
       currentVersion,
     );
-
     if (!isNewVersion || _isPopupShown) return;
+
+    // The endpoint says what has been released. It cannot say whether this
+    // client can install it, so check that separately -- and only now that a
+    // release has actually been announced, so the common case stays one
+    // request per check.
+    if (kIsWeb) {
+      final canInstall = await _webReloadWouldInstallUpdate(
+        versionInfo.version,
+        currentVersion,
+      );
+      if (!canInstall) return;
+    } else if (versionInfo.downloadUri == null) {
+      log(
+        'Update ${versionInfo.version} announced with an unusable '
+        'download_url "${versionInfo.downloadUrl}"; suppressing update popup',
+        path: 'update_bloc => _checkForUpdates',
+        isError: true,
+      );
+      return;
+    }
 
     PopupDispatcher(
       barrierDismissible: false,
@@ -44,11 +83,71 @@ class UpdateBloc extends BlocBase {
         },
         onCancel: () {
           _isPopupShown = false;
-          _checkerTime.cancel();
+          _checkerTime?.cancel();
         },
       ),
     ).show();
     _isPopupShown = true;
+  }
+
+  /// Whether reloading this page could actually install the announced release.
+  ///
+  /// A reload can only ever install what this origin is currently serving.
+  /// Production is deployed by hand from a different Firebase project than the
+  /// one CI deploys, so an announced release routinely runs ahead of the site
+  /// a given user is on -- and offering an update that reloads onto the same
+  /// build both fails and re-offers itself on every subsequent check.
+  ///
+  /// An unknown deployed version counts as "cannot install". That is
+  /// deliberately fail-closed: the cost is a missed notification, against a
+  /// popup that provably cannot do what it says.
+  Future<bool> _webReloadWouldInstallUpdate(
+    String announcedVersion,
+    String currentVersion,
+  ) async {
+    final now = DateTime.now();
+    if (_gateAnnouncedVersion == announcedVersion &&
+        _gateCheckedAt != null &&
+        now.difference(_gateCheckedAt!) < _gateRecheckInterval) {
+      // Already established that this announcement is unsatisfiable here. A
+      // site can lag the announcement by months, so re-fetching version.json
+      // every five minutes for the rest of the session buys nothing.
+      return false;
+    }
+
+    final deployedVersion = await appUpdateService.fetchDeployedWebVersion();
+    final canInstall = deployedVersion != null &&
+        isVersionGreaterThan(deployedVersion, currentVersion);
+
+    if (!canInstall) {
+      _gateAnnouncedVersion = announcedVersion;
+      _gateCheckedAt = now;
+      log(
+        'Update $announcedVersion announced, but this origin serves '
+        '${deployedVersion ?? 'an undeterminable version'} while the app runs '
+        '$currentVersion; a reload would install nothing. Suppressing popup.',
+        path: 'update_bloc => _webReloadWouldInstallUpdate',
+      );
+    }
+    return canInstall;
+  }
+
+  Future<void> update(UpdateVersionInfo versionInfo) async {
+    if (kIsWeb) {
+      await hardReloadPage();
+      return;
+    }
+
+    final Uri? downloadUri = versionInfo.downloadUri;
+    if (downloadUri == null) {
+      log(
+        'App update failed: unusable download URL "${versionInfo.downloadUrl}"',
+        path: 'update_bloc => update',
+        isError: true,
+      );
+      return;
+    }
+    await launchURLString(downloadUri.toString(), inSeparateTab: true);
   }
 
   Future<String> _getCurrentAppVersion() async {
@@ -56,27 +155,38 @@ class UpdateBloc extends BlocBase {
     return packageInfo.version;
   }
 
-  bool _isVersionGreaterThan(String newVersion, String currentVersion) {
-    if (newVersion == currentVersion) return false;
-
-    final int currentV = int.parse(currentVersion.replaceAll('.', ''));
-    final int newV = int.parse(newVersion.replaceAll('.', ''));
-
-    return newV > currentV;
-  }
-
-  Future<void> init() async {
-    await _checkForUpdates();
-    _checkerTime = Timer.periodic(
-      const Duration(minutes: 5),
-      (_) async => await _checkForUpdates(),
-    );
-  }
-
-  Future<void> update() async {
-    if (kIsWeb) {
-      reloadPage();
+  /// Whether [newVersion] is strictly newer than [currentVersion].
+  ///
+  /// Compares dotted versions segment by segment and numerically. The previous
+  /// implementation concatenated the digits (`0.9.20` became `920`), which
+  /// ranked `0.9.20` above `0.10.0`, and threw outright on any version
+  /// carrying a suffix -- an uncaught error inside the five-minute timer.
+  ///
+  /// Tolerates unequal segment counts (`1.0` == `1.0.0`) and ignores build and
+  /// pre-release suffixes, so `0.9.5-rc1` compares as `0.9.5`. Returns false
+  /// for anything it cannot parse, so malformed input can never raise a popup.
+  static bool isVersionGreaterThan(String newVersion, String currentVersion) {
+    List<int> parse(String version) {
+      final core = version.trim().split(RegExp(r'[+-]')).first;
+      return core
+          .split('.')
+          .map((s) => int.tryParse(s.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0)
+          .toList();
     }
+
+    final newSegments = parse(newVersion);
+    final currentSegments = parse(currentVersion);
+    final length = newSegments.length > currentSegments.length
+        ? newSegments.length
+        : currentSegments.length;
+
+    for (var i = 0; i < length; i++) {
+      final newSegment = i < newSegments.length ? newSegments[i] : 0;
+      final currentSegment =
+          i < currentSegments.length ? currentSegments[i] : 0;
+      if (newSegment != currentSegment) return newSegment > currentSegment;
+    }
+    return false;
   }
 }
 
@@ -93,4 +203,16 @@ class UpdateVersionInfo {
   final String changelog;
   final String downloadUrl;
   final UpdateStatus status;
+
+  /// The download URL as a usable http(s) [Uri], or null when it is absent or
+  /// not something we are willing to hand to the platform's URL launcher.
+  Uri? get downloadUri {
+    final url = downloadUrl.trim();
+    if (url.isEmpty) return null;
+    final uri = Uri.tryParse(url);
+    if (uri == null || !(uri.isScheme('https') || uri.isScheme('http'))) {
+      return null;
+    }
+    return uri;
+  }
 }

--- a/lib/services/app_update_service/app_update_service.dart
+++ b/lib/services/app_update_service/app_update_service.dart
@@ -3,26 +3,99 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:web_dex/blocs/update_bloc.dart';
 import 'package:web_dex/shared/constants.dart';
+import 'package:web_dex/shared/utils/utils.dart';
+import 'package:web_dex/shared/utils/window/window.dart';
 
 const AppUpdateService appUpdateService = AppUpdateService();
 
 class AppUpdateService {
   const AppUpdateService();
 
+  /// The announced release, from the update endpoint.
+  ///
+  /// The endpoint takes no parameters: it answers every caller with the same
+  /// constant, regardless of platform or installed version. It therefore says
+  /// what the latest *release* is, and nothing about what any given client can
+  /// actually install. Deciding that is [UpdateBloc]'s job.
   Future<UpdateVersionInfo?> getUpdateInfo() async {
     try {
-      final http.Response response = await http.post(
-        Uri.parse(updateCheckerEndpoint),
-      );
-      final Map<String, dynamic> json = jsonDecode(response.body);
+      final http.Response response = await http
+          .post(Uri.parse(updateCheckerEndpoint))
+          .timeout(const Duration(seconds: 15));
 
+      // Without this a 5xx HTML error page reaches jsonDecode, and the failure
+      // surfaces as a parse error rather than as the outage it is.
+      if (response.statusCode != 200) {
+        log(
+          'Update info request failed with status ${response.statusCode}',
+          path: 'app_update_service => getUpdateInfo',
+          isError: true,
+        );
+        return null;
+      }
+
+      final Map<String, dynamic> json = jsonDecode(response.body);
       return UpdateVersionInfo(
         status: _getStatus(json['status'] ?? ''),
         version: json['new_version'] ?? '',
         changelog: json['changelog'] ?? '',
         downloadUrl: json['download_url'] ?? '',
       );
-    } catch (e) {
+    } catch (e, s) {
+      log(
+        'Failed to fetch update info: $e',
+        path: 'app_update_service => getUpdateInfo',
+        trace: s,
+        isError: true,
+      );
+      return null;
+    }
+  }
+
+  /// The version the web app is actually being served, read from the
+  /// `version.json` Flutter emits next to `index.html`.
+  ///
+  /// This is the only thing that says what a reload would install. The update
+  /// endpoint cannot: it is parameterless, and production is deployed by hand
+  /// from a different Firebase project than the one CI deploys, so an
+  /// announced release routinely runs ahead of what a given site serves.
+  ///
+  /// Returns null when the answer cannot be established. Callers must treat
+  /// null as "unknown", never as "up to date".
+  Future<String?> fetchDeployedWebVersion() async {
+    try {
+      final uri = Uri.parse('${getOriginUrl()}/version.json').replace(
+        queryParameters: {
+          // version.json is served `no-cache` (see firebase.json), but that
+          // header only exists on sites deployed since it was added, and
+          // production deploys by hand. Until then this site still answers
+          // max-age=3600, and a cached copy would defeat the whole check. A
+          // unique query string is a different HTTP cache key, and also falls
+          // through the RESOURCES map of any legacy caching service worker.
+          'cb': DateTime.now().millisecondsSinceEpoch.toString(),
+        },
+      );
+      final http.Response response =
+          await http.get(uri).timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) {
+        log(
+          'version.json fetch failed with status ${response.statusCode}',
+          path: 'app_update_service => fetchDeployedWebVersion',
+          isError: true,
+        );
+        return null;
+      }
+
+      final version = (jsonDecode(response.body)
+          as Map<String, dynamic>)['version'] as String?;
+      return (version == null || version.isEmpty) ? null : version;
+    } catch (e, s) {
+      log(
+        'Failed to fetch deployed version.json: $e',
+        path: 'app_update_service => fetchDeployedWebVersion',
+        trace: s,
+        isError: true,
+      );
       return null;
     }
   }

--- a/lib/shared/utils/window/window_native.dart
+++ b/lib/shared/utils/window/window_native.dart
@@ -62,3 +62,7 @@ void showMessageBeforeUnload(String message) {
   _observer ??= _BeforeUnloadObserver(message);
   WidgetsBinding.instance.addObserver(_observer!);
 }
+
+/// No-op. Native builds install an update by downloading a release rather than
+/// reloading a page; see [UpdateBloc.update].
+Future<void> hardReloadPage() async {}

--- a/lib/shared/utils/window/window_stub.dart
+++ b/lib/shared/utils/window/window_stub.dart
@@ -5,3 +5,7 @@ String getOriginUrl() {
 void showMessageBeforeUnload(String message) {
   throw UnsupportedError('stub showMessageBeforeUnload');
 }
+
+Future<void> hardReloadPage() async {
+  throw UnsupportedError('stub hardReloadPage');
+}

--- a/lib/shared/utils/window/window_web.dart
+++ b/lib/shared/utils/window/window_web.dart
@@ -13,3 +13,62 @@ void showMessageBeforeUnload(String message) {
       ..returnValue = message;
   }.toJS;
 }
+
+/// Reloads the page, bypassing everything this client controls that could
+/// serve it the build it is already running.
+///
+/// The dominant cause of a stale reload is the HTTP cache: the boot files are
+/// served at stable names, so a client holds them for the full `max-age`.
+/// **JS cannot purge the HTTP cache**, so that half is fixed by response
+/// headers in `firebase.json`, not here.
+///
+/// What this function can do is drop the two client-side caches that would
+/// otherwise survive a reload, and get out of the way of the reload itself:
+///
+/// - Service workers. Both deployed sites currently serve Flutter's modern
+///   self-unregistering worker, which caches nothing, so in practice there is
+///   usually nothing to remove. This is kept for clients still pinned by an
+///   older caching `flutter_service_worker.js`, which would otherwise answer
+///   the reload from its own `RESOURCES` map.
+/// - `CacheStorage`. Neither the app nor the SDK writes to it, so anything
+///   found there was put there by a service worker and is safe to drop.
+///   Wallet data is untouched: seeds and Hive boxes live in IndexedDB and
+///   `localStorage`, which `caches.delete()` cannot reach.
+///
+/// Never throws, and always reloads: every cleanup step is best-effort, and a
+/// reload that skipped them still beats no reload at all.
+Future<void> hardReloadPage() async {
+  try {
+    // main_layout registers a beforeunload handler on web. Left in place it
+    // turns the reload into a browser confirmation dialog the user has to
+    // accept, immediately after they already confirmed in our own popup.
+    web.window.onbeforeunload = null;
+  } catch (_) {}
+
+  try {
+    await _clearClientSideCaches().timeout(const Duration(seconds: 3));
+  } catch (_) {
+    // Unavailable API, insecure context, or slow cleanup. Reload regardless:
+    // the headers are what the reload actually depends on.
+  }
+
+  web.window.location.reload();
+}
+
+Future<void> _clearClientSideCaches() async {
+  try {
+    final registrations =
+        (await web.window.navigator.serviceWorker.getRegistrations().toDart)
+            .toDart;
+    for (final registration in registrations) {
+      await registration.unregister().toDart;
+    }
+  } catch (_) {}
+
+  try {
+    final cacheKeys = (await web.window.caches.keys().toDart).toDart;
+    for (final key in cacheKeys) {
+      await web.window.caches.delete(key.toDart).toDart;
+    }
+  } catch (_) {}
+}

--- a/lib/shared/widgets/update_popup.dart
+++ b/lib/shared/widgets/update_popup.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/blocs/update_bloc.dart';
+import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 
@@ -110,7 +111,22 @@ class UpdatePopUp extends StatelessWidget {
                   backgroundColor: Theme.of(context).colorScheme.secondary,
                   onPressed: () async {
                     onAccept();
-                    await updateBloc.update();
+                    // Close before starting the update. On web the update is a
+                    // page reload, so nothing after this runs -- but if the
+                    // reload is blocked or the native download launcher throws,
+                    // leaving the dialog up strands the user behind a modal
+                    // that has no dismiss button.
+                    Navigator.of(context).pop();
+                    try {
+                      await updateBloc.update(versionInfo);
+                    } catch (e, s) {
+                      log(
+                        'Failed to start the app update: $e',
+                        path: 'update_popup => updateNow',
+                        trace: s,
+                        isError: true,
+                      );
+                    }
                   },
                 ),
               ),

--- a/lib/views/main_layout/main_layout.dart
+++ b/lib/views/main_layout/main_layout.dart
@@ -13,8 +13,7 @@ import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/analytics/events/misc_events.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
-// TODO(migration): Re-enable once update checker endpoint is migrated
-// import 'package:web_dex/blocs/update_bloc.dart';
+import 'package:web_dex/blocs/update_bloc.dart';
 import 'package:web_dex/common/screen.dart';
 
 import 'package:web_dex/model/authorize_mode.dart';
@@ -71,8 +70,7 @@ class _MainLayoutState extends State<MainLayout> {
     final tradingStatusBloc = context.read<TradingStatusBloc>();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      // TODO(migration): Re-enable once update checker endpoint is migrated
-      // await updateBloc.init();
+      await updateBloc.init();
 
       if (mounted) {
         try {

--- a/test_units/main.dart
+++ b/test_units/main.dart
@@ -63,6 +63,7 @@ import 'tests/helpers/max_min_rational_tests.dart';
 import 'tests/helpers/total_24_change_tests.dart';
 import 'tests/helpers/total_fee_test.dart';
 import 'tests/helpers/update_sell_amount_tests.dart';
+import 'tests/helpers/update_version_compare_tests.dart';
 import 'tests/gasless/tron_gasless_policy_test.dart';
 import 'tests/password/validate_password_tests.dart';
 import 'tests/password/validate_rpc_password_tests.dart';
@@ -131,6 +132,11 @@ import 'tests/utils/transaction_history/sanitize_transaction_tests.dart';
 ///   --dart-define=TRON_GASLESS_SERVICE_PROVIDER=TLntW9Z59LYY5KEi9cmwk3PKjQga828ird
 /// ```
 void main() {
+  group('App update:', () {
+    testUpdateVersionCompare();
+    testUpdateDownloadUri();
+  });
+
   group('Formatters:', () {
     testCutTrailingZeros();
     testFormatAmount();

--- a/test_units/tests/helpers/update_version_compare_tests.dart
+++ b/test_units/tests/helpers/update_version_compare_tests.dart
@@ -1,0 +1,83 @@
+import 'package:test/test.dart';
+import 'package:web_dex/blocs/update_bloc.dart';
+
+/// Covers [UpdateBloc.isVersionGreaterThan], which decides whether the update
+/// popup is offered at all.
+void testUpdateVersionCompare() {
+  group('UpdateBloc.isVersionGreaterThan:', () {
+    test('orders ordinary releases', () {
+      expect(UpdateBloc.isVersionGreaterThan('0.9.7', '0.9.6'), isTrue);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.6', '0.9.7'), isFalse);
+      expect(UpdateBloc.isVersionGreaterThan('1.0.0', '0.9.9'), isTrue);
+    });
+
+    test('never offers an update to the version already running', () {
+      expect(UpdateBloc.isVersionGreaterThan('0.9.7', '0.9.7'), isFalse);
+    });
+
+    test('compares segments numerically, not as concatenated digits', () {
+      // The previous implementation stripped the dots and parsed the result,
+      // so 0.9.20 became 920 and 0.10.0 became 100 -- ranking the older
+      // release higher and offering users a downgrade.
+      expect(UpdateBloc.isVersionGreaterThan('0.9.20', '0.10.0'), isFalse);
+      expect(UpdateBloc.isVersionGreaterThan('0.10.0', '0.9.20'), isTrue);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.10', '0.9.9'), isTrue);
+    });
+
+    test('tolerates unequal segment counts', () {
+      expect(UpdateBloc.isVersionGreaterThan('1.0', '1.0.0'), isFalse);
+      expect(UpdateBloc.isVersionGreaterThan('1.0.1', '1.0'), isTrue);
+      expect(UpdateBloc.isVersionGreaterThan('2', '1.9.9'), isTrue);
+    });
+
+    test('ignores build and pre-release suffixes instead of throwing', () {
+      // The previous implementation called int.parse on "097-rc1" and threw,
+      // uncaught, inside the five-minute periodic check.
+      expect(UpdateBloc.isVersionGreaterThan('0.9.7-rc1', '0.9.7'), isFalse);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.8-rc1', '0.9.7'), isTrue);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.7+2', '0.9.7+1'), isFalse);
+    });
+
+    test('treats unparseable input as "no update"', () {
+      expect(UpdateBloc.isVersionGreaterThan('', '0.9.7'), isFalse);
+      expect(UpdateBloc.isVersionGreaterThan('not-a-version', '0.9.7'), isFalse);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.8', ''), isTrue);
+    });
+
+    test('matches the versions in production today', () {
+      // The endpoint announces 0.9.6; walletrc serves 0.9.7 and dex.gleec.com
+      // serves 0.9.4. Only the second of these may raise a popup.
+      expect(UpdateBloc.isVersionGreaterThan('0.9.6', '0.9.7'), isFalse);
+      expect(UpdateBloc.isVersionGreaterThan('0.9.6', '0.9.4'), isTrue);
+    });
+  });
+}
+
+/// Covers the download-URL guard that decides whether a native update can be
+/// started at all.
+void testUpdateDownloadUri() {
+  group('UpdateVersionInfo.downloadUri:', () {
+    UpdateVersionInfo infoWith(String url) => UpdateVersionInfo(
+          status: UpdateStatus.available,
+          version: '0.9.8',
+          changelog: '',
+          downloadUrl: url,
+        );
+
+    test('accepts http(s) release URLs', () {
+      expect(
+        infoWith('https://github.com/GLEECBTC/gleec-wallet/releases/tag/0.9.6')
+            .downloadUri,
+        isNotNull,
+      );
+      expect(infoWith('  https://example.com/a  ').downloadUri, isNotNull);
+    });
+
+    test('rejects everything that is not an http(s) URL', () {
+      expect(infoWith('').downloadUri, isNull);
+      expect(infoWith('   ').downloadUri, isNull);
+      expect(infoWith('javascript:alert(1)').downloadUri, isNull);
+      expect(infoWith('file:///etc/passwd').downloadUri, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Replaces #3521, re-derived rather than restored. Several of that PR's stated premises did not survive checking against the deployed sites, and its header list was incomplete in a way that would have left the button broken.

**Stacked on #3514** so the `firebase.json` conflict is resolved by construction — the two branches touch the same `headers` array and conflict when merged independently. Retarget to `dev` once #3514 lands.

## Why this is needed

`updateBloc.init()` has been commented out since the endpoint migration, so the update checker does not run at all today. Turning it back on alone is not enough.

The endpoint is live and answers correctly, but it is **parameterless** — `GET`, bare `POST`, a platform in the body and query params all return the same constant. It reports the latest *release* and can say nothing about what a given client can install. That distinction drives most of this change.

## What was wrong in #3521

**"A legacy caching service worker is serving the stale build" — this is not the case.** Both deployed sites serve Flutter's modern self-unregistering worker: 783 bytes, no `RESOURCES` map, never calls `caches.delete`, unregisters itself on activate. There is no SW cache left to defeat.

**The cause is the HTTP cache, and the header list was short.** Every version-coupled boot file is served at a stable name under Firebase's default `max-age=3600`:

| file | #3521 | here |
|---|---|---|
| `index.html` | yes | yes |
| `flutter_bootstrap.js` | yes | yes |
| `flutter.js` | yes | yes |
| `main.dart.js` | **no** | yes |
| `version.json` | **no** | yes |
| `flutter_service_worker.js` | **no** | yes |

`main.dart.js` is the compiled application. Revalidating `index.html` alone re-serves a fresh shell that boots an hour-old app, so #3521 would not reliably have fixed the button it was written for. `version.json` is included because `UpdateBloc` now reads it to make its decision.

**The gate re-probed indefinitely.** #3521 re-fetched `version.json` every five minutes for the whole session. On `dex.gleec.com`, four months behind, that never resolves — 288 requests a day that cannot change the answer.

## What this does

- **`firebase.json`** revalidates all six boot files. JS cannot purge the HTTP cache, so these headers are the only thing that can fix that half. Preserves #3514's "each glob owns a disjoint set of header keys" invariant.
- **`hardReloadPage`** drops the `beforeunload` handler `main_layout` installs, then clears service workers and `CacheStorage` before reloading. Kept as defence for clients still pinned by an older caching worker, with a comment saying so rather than asserting it is the cause. Verified safe: neither app nor SDK writes to `CacheStorage`, and seeds and Hive boxes live in IndexedDB and `localStorage`, which `caches.delete()` cannot reach.
- **`UpdateBloc` gates the popup on what is installable.** A reload can only install what this origin serves, and production is hand-deployed from a different Firebase project than CI deploys — `dex.gleec.com` serves `0.9.4` while the endpoint announces `0.9.6`. Unknown counts as "cannot install"; a negative verdict is cached for 30 minutes so a lagging site is probed twice an hour, not 288 times a day, while a landing deploy is still noticed promptly. Native gets the matching guard: no usable `download_url`, no popup.
- **`isVersionGreaterThan`** compares segments numerically. The old code stripped dots and parsed the digits, so `0.9.20` became `920` and outranked `0.10.0` (`100`), and it threw on any suffixed version — uncaught, inside the five-minute timer.
- **`UpdatePopUp`** closes before awaiting the update, so a blocked reload or failed launcher cannot strand the user behind a modal with no dismiss button.

## Effect on merge

None visible. `pubspec` is `0.9.7`, the endpoint announces `0.9.6`, so no popup can appear until the endpoint is bumped as part of a release. This is what makes that bump safe.

Note the headers only take effect where they are deployed. CI deploys `walletrc` only, so production users get this when `gleec-wallet-official` is next deployed by hand — the same deploy #3514 is waiting on. Until then the gate is what stops those users being offered an update that cannot land.

## Testing

- 9 new unit tests in `test_units/tests/helpers/update_version_compare_tests.dart`, registered in `test_units/main.dart`, all passing on Flutter 3.41.4. They cover the digit-concatenation ordering bug, the suffix throw, unequal segment counts, unparseable input, the versions live in production today, and the `download_url` scheme guard.
- `flutter analyze` clean on all changed files apart from one pre-existing `use_super_parameters` info in `update_popup.dart`.
- `pubspec.lock` unchanged, so `--enforce-lockfile` is unaffected.

Not tested: the reload itself and the header behaviour, which can only be verified against a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)