### PR TITLE
fix(onboarding): tighten inline agreement spacing

### DIFF
--- a/lib/shared/widgets/disclaimer/terms_consent_text.dart
+++ b/lib/shared/widgets/disclaimer/terms_consent_text.dart
@@ -44,6 +44,9 @@ class _AgreementNotice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textStyle = Theme.of(
+      context,
+    ).textTheme.bodyMedium?.copyWith(fontSize: 14, height: 1.5);
     final notice = LocaleKeys.onboardingAgreementNotice.tr(
       namedArgs: {'action': actionLabel},
     );
@@ -56,7 +59,8 @@ class _AgreementNotice extends StatelessWidget {
         final isEula = match.group(1) == 'eula';
         spans.add(
           WidgetSpan(
-            alignment: PlaceholderAlignment.middle,
+            alignment: PlaceholderAlignment.baseline,
+            baseline: TextBaseline.alphabetic,
             // WidgetSpan already scales its entire child with the paragraph.
             // Avoid applying the user's text scale a second time inside it.
             child: MediaQuery.withNoTextScaling(
@@ -68,14 +72,15 @@ class _AgreementNotice extends StatelessWidget {
                   link: true,
                   child: TextButton(
                     style: TextButton.styleFrom(
-                      minimumSize: const Size(48, 48),
-                      padding: const EdgeInsets.symmetric(horizontal: 4),
-                      textStyle: Theme.of(context).textTheme.bodyMedium
-                          ?.copyWith(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w700,
-                            decoration: TextDecoration.underline,
-                          ),
+                      // Inline links follow the sentence's line height (WCAG
+                      // 2.5.8's inline exception), not standalone button sizing.
+                      minimumSize: Size.zero,
+                      padding: EdgeInsets.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      textStyle: textStyle?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        decoration: TextDecoration.underline,
+                      ),
                     ),
                     onPressed: () => _showDocument(context, isEula: isEula),
                     child: Text(
@@ -102,7 +107,7 @@ class _AgreementNotice extends StatelessWidget {
     return Text.rich(
       TextSpan(children: spans),
       key: const Key('legal-agreement-notice'),
-      style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontSize: 14),
+      style: textStyle,
     );
   }
 

--- a/test_units/shared/widgets/terms_consent_text_test.dart
+++ b/test_units/shared/widgets/terms_consent_text_test.dart
@@ -258,7 +258,7 @@ void main() {
       expect(accepted, 1);
     });
 
-    testWidgets('links expose labels and meet accessible target sizes', (
+    testWidgets('inline links expose accessible labels and actions', (
       tester,
     ) async {
       final semantics = tester.ensureSemantics();
@@ -284,10 +284,30 @@ void main() {
             ),
           );
         }
-        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+        // WCAG 2.5.8 exempts links within sentences from standalone target
+        // sizing. Keyboard access is covered above; labels still apply.
         await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       } finally {
         semantics.dispose();
+      }
+    });
+
+    testWidgets('inline links do not inflate the sentence line spacing', (
+      tester,
+    ) async {
+      await _pump(tester, documents: _LegalDocuments(), onAgree: () {});
+
+      final notice = find.byKey(const Key('legal-agreement-notice'));
+      // The sentence fits into three 21px lines at this width with the test
+      // font. Standalone button sizing must not add space between the lines.
+      expect(tester.getSize(notice).height, lessThanOrEqualTo(63));
+      for (final label in ['EULA', 'Terms & Conditions']) {
+        final text = find.text(label);
+        final button = find.ancestor(
+          of: text,
+          matching: find.byType(TextButton),
+        );
+        expect(tester.getSize(button).height, tester.getSize(text).height);
       }
     });
 


### PR DESCRIPTION
The EULA and Terms & Conditions links had 48px button bounds inside the agreement sentence, which forced oversized gaps between wrapped lines. This follow-up to #3527 gives the inline links compact bounds, aligns them to the text baseline, and uses consistent 1.5 line spacing.

Both links retain keyboard activation, focus behavior, underlining, and screen-reader labels. Links within a sentence use [WCAG 2.5.8’s inline exception](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html); standalone button target sizing should not stretch paragraph line spacing.

### Screenshots

Actual Flutter forms rendered with the app theme and sample wallet data. Mobile captures are 390 × 844; the hardware capture is 1024 × 900.

| Create — first use | Create — updated agreements |
| --- | --- |
| <img width="300" alt="Create form with inline legal notice" src="https://github.com/user-attachments/assets/cbfddb16-64d8-4273-898c-e0053767124c" /> | <img width="300" alt="Create form after legal agreements changed" src="https://github.com/user-attachments/assets/79b91a88-fc2a-4bb9-81d8-fdd585e92106" /> |

| Import recovery phrase — final step | Import encrypted file |
| --- | --- |
| <img width="300" alt="Final seed import form with updated agreements" src="https://github.com/user-attachments/assets/5f439c42-49a1-40c2-a4d6-ab03fed49884" /> | <img width="300" alt="Encrypted file import with updated agreements" src="https://github.com/user-attachments/assets/5926f017-7d42-4865-9ded-7842f6fa74ed" /> |

<details>
<summary>Returning-user login with updated agreements</summary>

<img width="390" alt="Login form with updated agreements" src="https://github.com/user-attachments/assets/d241fac1-09b6-40a8-a37e-3ae85fc17663" />

</details>

<details>
<summary>Desktop hardware wallet with updated agreements</summary>

<img width="768" alt="Desktop hardware wallet form with inline updated agreements" src="https://github.com/user-attachments/assets/c4537eff-2ca9-49e9-936b-543978c22f8b" />

</details>

### Validation

- Full PR-gating unit/widget suite with coverage and all four GasFree defines: **748 passed, 3 skipped**.
- **100% executable-line coverage** of `TermsConsentText` (46/46).
- New regression test checks compact paragraph height and verifies inline links add no vertical button padding. Existing tests cover both document links, keyboard activation, screen-reader labels, 320px/1024px layouts, and 200% text scaling. All tests are registered in `test_units/main.dart`.
- All six screenshots rendered without layout exceptions and visually reviewed.
- Changed Dart files formatted. Full PR-equivalent analysis passes with the existing 2,178 repository warnings/information and no errors.

UI-Pro Basis: typography, responsive forms, keyboard operation, and screen-reader accessibility. Gate Status: **exception** carried from #3527 because the referenced canonical design documents are absent from `dev`; this change follows the existing app theme. Design owns restoring those references in a separate follow-up.
